### PR TITLE
Fix TS devDependencies

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,8 +25,6 @@ export const devDependencies = [
  * These dev dependencies are for TypeScript projects.
  */
 export const devDependenciesTS = [
-  "@types/boxen",
-  "@types/chalk",
   "@types/clear",
   "@types/configstore",
   "@types/figlet",

--- a/src/init.ts
+++ b/src/init.ts
@@ -125,14 +125,9 @@ export const installDevDependencies = async (
   try {
     spinner.start();
     const installCommand = "npm";
-    let installArgs = ["install", "--save-dev"];
-    installArgs = installArgs.concat(devDependencies);
-
-    if (language === "ts") {
-      installArgs = installArgs.concat(devDependenciesTS);
-    } else {
-      installArgs = installArgs.concat(devDependencies);
-    }
+    const installArgs = ["install", "--save-dev"].concat(
+      language === "ts" ? devDependenciesTS : devDependencies
+    );
 
     // * Verify that the directory exists 1st
     const pathExists = await fs.pathExists(root);


### PR DESCRIPTION
This PR does two things to clean up devDeps for TS:

1) Remove stub `@types/boxen` and `@types/chalk` packages, as `boxen` and `chalk` provide their own types.
2) Undo adding `@babel/*` devDeps in TS, where they aren't used.